### PR TITLE
refactor: add background removal toggle (#1)

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,6 @@
   }
 }
 </script>
-<link rel="stylesheet" href="/index.css">
 </head>
   <body class="bg-slate-50 dark:bg-slate-900">
     <div id="root"></div>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,9 @@
       "DOM.Iterable"
     ],
     "skipLibCheck": true,
+    "types": [
+      "node"
+    ],
     "moduleResolution": "bundler",
     "isolatedModules": true,
     "moduleDetection": "force",


### PR DESCRIPTION
* refactor: Remove hardcoded base path in Vite config

The `base` configuration in vite.config.ts was set to `/asset-generator/`. This hardcoded value caused issues when deploying to different subdirectories or the root of a domain. Removing it allows Vite to infer the correct base path automatically, improving deployment flexibility.

* chore(release): 0.1.0

* chore(release): 0.2.0

* chore(release): 0.3.0

* feat: Add background removal toggle

Introduces a new state `shouldRemoveBackground` to control whether the white background removal feature is active. This allows users to choose to keep the original background.

Updates the loading message to reflect the current operation accurately. Also removes the unused `createImageFromFile` import and the `index.css` link. Resets the package version to 0.0.0.